### PR TITLE
add get_input function

### DIFF
--- a/try_install_all.py
+++ b/try_install_all.py
@@ -33,6 +33,7 @@ for engine in ENGINE_LIST:
 
     try:
         TEST_ENGINES[engine.abbreviation] = choose_engine(opts)
+        TEST_ENGINES[engine.abbreviation].get_input()
         TEST_ENGINES[engine.abbreviation].get_cursor()
     except:
         TEST_ENGINES[engine.abbreviation] = None
@@ -51,7 +52,8 @@ for module in MODULE_LIST:
             except Exception as e:
                 print("ERROR.")
                 errors.append((key, module.__name__, e))
-
+        elif (key, "No connection detected") not in errors:
+            errors.append((key, "No connection detected"))
 print('')
 if errors:
     print("Engine, Dataset, Error")


### PR DESCRIPTION
currently mysql engine is failing due to lack of connection.

since the retriever gets the opts using command line, get_input()
will ask the user for the opts and get_cursor() will use these values
to connect to the various engines.

In case an engine fails to connect we record that as an error as
errors.append((key, "No connection detected"))
if an engine error already exist, we do not add it in the error list

as we run the
